### PR TITLE
修理有關樓層、教室編號選擇的bug，並且調整排版，並更改沒有搜尋結果時顯示的文字

### DIFF
--- a/backend/src/main/java/ntou/cse/backend/ClassroomApply/controller/ClassroomApplyController.java
+++ b/backend/src/main/java/ntou/cse/backend/ClassroomApply/controller/ClassroomApplyController.java
@@ -112,4 +112,15 @@ public class ClassroomApplyController {
         return classroomApplyService.findApplicationsByBorrower(borrower);
     }
 
+    @DeleteMapping("/delete-null-borrower")
+    public ResponseEntity<String> deleteApplicationsWithNullBorrower() {
+        try {
+            classroomApplyService.deleteApplicationsWithNullBorrower();
+            return new ResponseEntity<>("Applications with null borrower deleted successfully", HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>("An error occurred while deleting applications", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
 }

--- a/backend/src/main/java/ntou/cse/backend/ClassroomApply/repo/ClassroomApplyRepository.java
+++ b/backend/src/main/java/ntou/cse/backend/ClassroomApply/repo/ClassroomApplyRepository.java
@@ -18,5 +18,5 @@ public interface ClassroomApplyRepository extends MongoRepository<ClassroomApply
     List<ClassroomApply> findByBorrowerAndStartTimeBeforeAndEndTimeAfter(String borrower, LocalDateTime endTime, LocalDateTime startTime);
     List<ClassroomApply> findByBorrowerAndFloorAndClassroomAndStartTimeBeforeAndEndTimeAfter(
             String borrower, String floor, String classroom, LocalDateTime endTime, LocalDateTime startTime);
-
+    List<ClassroomApply> findByBorrowerIsNull();
 }

--- a/backend/src/main/java/ntou/cse/backend/ClassroomApply/service/ClassroomApplyService.java
+++ b/backend/src/main/java/ntou/cse/backend/ClassroomApply/service/ClassroomApplyService.java
@@ -92,7 +92,15 @@ public class ClassroomApplyService {
     public List<ClassroomApply> findApplicationsByClassroomAndTime(String floor, String classroom, LocalDateTime startTime, LocalDateTime endTime) {
         return classroomApplyRepository.findByFloorAndClassroomAndStartTimeBetweenAndIsApprovedTrue(floor, classroom, startTime, endTime);
     }
+
     public List<ClassroomApply> findApplicationsByBorrower(String borrower) {
         return classroomApplyRepository.findByBorrower(borrower);
+    }
+
+    public void deleteApplicationsWithNullBorrower() {
+        List<ClassroomApply> applications = classroomApplyRepository.findByBorrowerIsNull();
+        if (!applications.isEmpty()) {
+            classroomApplyRepository.deleteAll(applications);
+        }
     }
 }

--- a/frontend/src/classroom_map_UI/MapDisplay.js
+++ b/frontend/src/classroom_map_UI/MapDisplay.js
@@ -15,7 +15,7 @@ const MapDisplay = ({ floor }) => {
 
     return (
         <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px' }}>
-            <Box sx={{ textAlign: 'center', marginTop: 2 }}>
+            <Box sx={{ textAlign: 'center' }}>
                 {floor && imageMap[floor] ? (
                     <img src={imageMap[floor]} alt={`${floor} floor map`} style={{ width: '80%' }} />
                 ) : (

--- a/frontend/src/classroom_query_UI/ClassroomQueryPaper.js
+++ b/frontend/src/classroom_query_UI/ClassroomQueryPaper.js
@@ -11,7 +11,7 @@ const ClassroomQueryPaper = ({ floor, setFloor, classroomCode, setClassroomCode,
         <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px'}}>
             <Grid2 container justifyContent="space-between" >
                 <Grid2 item xs={3} >
-                    <FloorAndClassroomCodeSelector floor={floor} setFloor={setFloor} classroomCode={classroomCode} setClassroomCode={setClassroomCode} />
+                    <FloorAndClassroomCodeSelector floor={floor} setFloor={setFloor} classroomCode={classroomCode} setClassroomCode={setClassroomCode} showAllOption={true}/>
                 </Grid2>
                 <Grid2 item xs={3} sx={{ display: 'flex', alignItems: 'center'}}>
                     <DisplayIsBanned

--- a/frontend/src/classroom_query_UI/ResultList.js
+++ b/frontend/src/classroom_query_UI/ResultList.js
@@ -6,12 +6,21 @@ import UpdateKeyStatusButton from "../key_status_UI/UpdateKeyStatusButton";
 import ExportScheduleButton from "../export/ExportScheduleButton";
 import ClassroomBanStatusButton from "../classroom_reserve_status/ClassroomBanStatusButton";
 import ClassroomUnbanStatusButton from "../classroom_reserve_status/ClassroomUnbanStatusButton";
-import {apiConfig} from "../config/apiConfig";
+import { apiConfig } from "../config/apiConfig";
 import { useTranslation } from 'react-i18next';
+
 export default function ResultList({ floor, classroomCode, reload, setReload, isBanned, setDisplayReload }) {
     const [classrooms, setClassrooms] = useState([]);
     const userRole = localStorage.getItem("userRole");
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+    const isChinese = i18n.language === 'zh_tw';
+
+    const styles = {
+        roomNumberWidth: isChinese ? "130px" : "150px",
+        floorWidth: isChinese ? "90px" : "85px",
+        statusWidth: isChinese ? "145px" : "245px",
+        keyStatusWidth: isChinese ? "210px" : "210px",
+    };
 
     useEffect(() => {
         const fetchClassrooms = async () => {
@@ -23,11 +32,10 @@ export default function ResultList({ floor, classroomCode, reload, setReload, is
                     url = `/classroom_build/floor/${floor}`;
                 }
                 const response = await apiConfig.get(url);
-                if (response.status !== 200 ) throw new Error('Network response was not ok');
+                if (response.status !== 200) throw new Error('Network response was not ok');
                 const data = await response.data;
                 const classroomData = Array.isArray(data) ? data : [data];
                 setClassrooms(classroomData);
-                console.log(classroomData);
             } catch (error) {
                 console.error("Error fetching classroom data", error);
             }
@@ -43,7 +51,9 @@ export default function ResultList({ floor, classroomCode, reload, setReload, is
     return (
         <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px' }}>
             {classrooms.length === 0 ? (
-                <Typography variant="body1">{t("沒有找到相關的教室")}</Typography>
+                <Typography variant="body1" sx={{ textAlign: 'center', marginTop: 2, marginBottom: 2 }}>
+                    {t("沒有找到相關的教室，請檢查後端是否已經啟動，並且資料庫中確實存在資料")}
+                </Typography>
             ) : (
                 classrooms.map((classroom) => (
                     <Box
@@ -59,18 +69,18 @@ export default function ResultList({ floor, classroomCode, reload, setReload, is
                         }}
                     >
                         <Box sx={{ display: 'flex', gap: 2 }}>
-                            <Typography variant="body1" sx={{ minWidth: '110px' }}>
+                            <Typography variant="body1" sx={{ minWidth: styles.roomNumberWidth }}>
                                 {t("教室編號")}: {classroom.roomNumber}
                             </Typography>
-                            <Typography variant="body1" sx={{ minWidth: '70px' }}>
+                            <Typography variant="body1" sx={{ minWidth: styles.floorWidth }}>
                                 {t("樓層")}: {classroom.floor}
                             </Typography>
-                            <Typography variant="body1" sx={{ minWidth: '125px' }}>
+                            <Typography variant="body1" sx={{ minWidth: styles.statusWidth }}>
                                 {t("教室狀態")}: {classroom.banned ? t('不可用') : t('可用')}
                             </Typography>
                             {userRole !== "borrower" && (
                                 <>
-                                    <Typography variant="body1" sx={{ minWidth: '192px' }}>
+                                    <Typography variant="body1" sx={{ minWidth: styles.keyStatusWidth }}>
                                         {t("鑰匙狀態")}: {classroom.keyStatus}
                                     </Typography>
                                     {classroom.borrower && (

--- a/frontend/src/classroom_reserve_status/ClassroomBanStatus.js
+++ b/frontend/src/classroom_reserve_status/ClassroomBanStatus.js
@@ -110,7 +110,7 @@ const ClassroomBanStatus = ({ open, onClose, initialFloor, initialClassroomCode,
                                 <Box sx={{ paddingTop: 1.5, paddingBottom: 1.5, paddingLeft: 4, paddingRight: 4 }}>
                                     <FloorAndClassroomCodeSelector
                                         floor={floor} setFloor={setFloor}
-                                        classroomCode={classroomCode} setClassroomCode={setClassroomCode}
+                                        classroomCode={classroomCode} setClassroomCode={setClassroomCode} disabled={true}
                                     />
                                 </Box>
                                 <CardContent sx={{ paddingTop: 1.5, paddingBottom: 2, paddingLeft: 4, paddingRight: 4 }}>

--- a/frontend/src/design_apply_list_UI/ApplyList.js
+++ b/frontend/src/design_apply_list_UI/ApplyList.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Typography, Paper, Button, Grid2 } from '@mui/material';
 import FloorAndClassroomCodeSelector from "../floor_and_classroom_code_selection/FloorAndClassroomCodeSelector";
 import HistoryDialog from './historyDialog';
-import {apiConfig} from "../config/apiConfig";
+import { apiConfig } from "../config/apiConfig";
 import { useTranslation } from 'react-i18next';
 
 export default function ApplyList() {
@@ -13,7 +13,17 @@ export default function ApplyList() {
     const [open, setOpen] = useState(false);
     const [floor, setFloor] = useState('');
     const [classroomCode, setClassroomCode] = useState('');
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+
+    // Check the language for dynamic styling
+    const isChinese = i18n.language === 'zh_tw';
+    const styles = {
+        classroomIdWidth: isChinese ? "160px" : "180px",
+        floorWidth: isChinese ? "110px" : "110px",
+        userWidth: isChinese ? "180px" : "200px",
+        rentalTimeWidth: isChinese ? "450px" : "460px",
+        isRentedWidth: isChinese ? "160px" : "160px",
+    };
 
     useEffect(() => {
         apiConfig
@@ -95,18 +105,6 @@ export default function ApplyList() {
             });
     };
 
-    const formatTime = (date) => {
-        return new Date(date).toLocaleString('zh-TW', {
-            hour12: true, // 設定 12 小時制 (AM/PM)
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-        });
-    };
-
     return (
         <Box>
             <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px' }}>
@@ -117,6 +115,7 @@ export default function ApplyList() {
                             setFloor={setFloor}
                             classroomCode={classroomCode}
                             setClassroomCode={setClassroomCode}
+                            showAllOption={true}
                             required
                         />
                     </Grid2>
@@ -124,8 +123,8 @@ export default function ApplyList() {
             </Paper>
             <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px' }}>
                 {filteredApplications.length === 0 ? (
-                    <Typography variant="h6" sx={{mt: 2}} sx={{ textTransform: "none" }}>
-                        {t('目前沒有符合篩選條件的申請')}
+                    <Typography variant="body1" sx={{ textAlign: 'center', marginTop: 2, marginBottom: 2 }}>
+                        {t("沒有找到相關的申請，請檢查後端是否已經啟動，並且資料庫中確實存在資料")}
                     </Typography>
                 ) : (
                     filteredApplications.map((result) => (
@@ -142,12 +141,12 @@ export default function ApplyList() {
                             }}
                         >
                             <Box sx={{display: 'flex', gap: 2}}>
-                                <Typography variant="body1" sx={{minWidth: '125px'}}>{t('教室編號')}: {result.classroom}</Typography>
-                                <Typography variant="body1" sx={{minWidth: '80px'}}>{t('樓層')}: {result.floor}</Typography>
-                                <Typography variant="body1" sx={{minWidth: '185px'}}>
+                                <Typography variant="body1" sx={{minWidth: styles.classroomIdWidth}}>{t('教室編號')}: {result.classroom}</Typography>
+                                <Typography variant="body1" sx={{minWidth: styles.floorWidth}}>{t('樓層')}: {result.floor}</Typography>
+                                <Typography variant="body1" sx={{minWidth: styles.userWidth}}>
                                     {t('借用人')}: {result.borrower ? result.borrower : t('未知使用者')}
                                 </Typography>
-                                <Typography variant="body1">
+                                <Typography variant="body1" sx={{minWidth: styles.rentalTimeWidth}}>
                                     {t('借用時間')}: {`${new Date(result.startTime).toLocaleString('zh-TW', { hour12: false })} ${t('到')} ${new Date(result.endTime).toLocaleString('zh-TW', { hour12: false })}`}
                                 </Typography>
                             </Box>
@@ -188,9 +187,9 @@ export default function ApplyList() {
                                     borderRadius: '20px',
                                 }}
                             >
-                                <Typography variant="body1" sx={{minWidth: '170px'}}> {t('借用人')}: {info.user}</Typography>
-                                <Typography variant="body1" sx={{minWidth: '170px'}}> {t('教室編號')}: {info.classroom}</Typography>
-                                <Typography variant="body1" sx={{minWidth: '195px'}}> {t('借用日期')}: {info.rentalDate}</Typography>
+                                <Typography variant="body1" sx={{minWidth: styles.userWidth}}> {t('借用人')}: {info.user}</Typography>
+                                <Typography variant="body1" sx={{minWidth: styles.classroomIdWidth}}> {t('教室編號')}: {info.classroom}</Typography>
+                                <Typography variant="body1" sx={{minWidth: '210px'}}> {t('借用日期')}: {info.rentalDate}</Typography>
                                 <Typography variant="body1">{t('審查結果')}: {info.isRented}</Typography>
                             </Box>
                         ))

--- a/frontend/src/floor_and_classroom_code_selection/ClassroomCodeSelector.js
+++ b/frontend/src/floor_and_classroom_code_selection/ClassroomCodeSelector.js
@@ -3,7 +3,7 @@ import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import {apiConfig} from "../config/apiConfig";
 import { useTranslation } from 'react-i18next';
 
-export default function ClassroomCodeSelector({ floor, classroomCode, setClassroomCode }) {
+export default function ClassroomCodeSelector({ floor, classroomCode, setClassroomCode, showAllOption = false, disabled = false }) {
     const [classroomCodes, setClassroomCodes] = useState([]);
     const { t } = useTranslation();
 
@@ -12,16 +12,16 @@ export default function ClassroomCodeSelector({ floor, classroomCode, setClassro
             apiConfig.get(`/classroom_build/floor/${floor}`)
                 .then((response) => response.data)
                 .then((data) => {
-                    const codes = data.map((classroom) => classroom.roomNumber);
-                    setClassroomCodes(['全部', ...codes]);
+                    const codes = showAllOption ? ['全部', ...data.map((classroom) => classroom.roomNumber)] : data.map((classroom) => classroom.roomNumber);
+                    setClassroomCodes(codes);
                 })
                 .catch((error) => {
                     console.error('Error fetching classrooms:', error);
                 });
         } else {
-            setClassroomCodes(['全部']);
+            setClassroomCodes(showAllOption ? ['全部'] : []);
         }
-    }, [floor]);
+    }, [floor, showAllOption]);
 
     const handleChange = (event) => {
         const value = event.target.value;
@@ -36,6 +36,7 @@ export default function ClassroomCodeSelector({ floor, classroomCode, setClassro
                 value={classroomCode === null ? '全部' : classroomCode}
                 onChange={handleChange}
                 label={t('classroomCodeSelector.教室編號')}
+                disabled={disabled}
             >
                 {classroomCodes.map((code) => (
                     <MenuItem key={code} value={code}>

--- a/frontend/src/floor_and_classroom_code_selection/FloorAndClassroomCodeSelector.js
+++ b/frontend/src/floor_and_classroom_code_selection/FloorAndClassroomCodeSelector.js
@@ -2,11 +2,12 @@ import { Box } from '@mui/material';
 import FloorSelector from './FloorSelector';
 import ClassroomCodeSelector from './ClassroomCodeSelector';
 
-export default function FloorAndClassroomCodeSelector({ floor, setFloor, classroomCode, setClassroomCode }) {
+export default function FloorAndClassroomCodeSelector({ floor, setFloor, classroomCode, setClassroomCode, showAllOption, disabled }) {
+
     return (
         <Box sx={{ display: 'flex', gap: 2, flexDirection: 'row', width: '100%' }}>
-            <FloorSelector floor={floor} setFloor={setFloor} setClassroomCode={setClassroomCode}/>
-            <ClassroomCodeSelector floor={floor} classroomCode={classroomCode} setClassroomCode={setClassroomCode} />
+            <FloorSelector floor={floor} setFloor={setFloor} setClassroomCode={setClassroomCode} showAllOption={showAllOption} disabled={disabled}/>
+            <ClassroomCodeSelector floor={floor} classroomCode={classroomCode} setClassroomCode={setClassroomCode} showAllOption={showAllOption} disabled={disabled}/>
         </Box>
     );
 }

--- a/frontend/src/floor_and_classroom_code_selection/FloorSelector.js
+++ b/frontend/src/floor_and_classroom_code_selection/FloorSelector.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import {apiConfig} from "../config/apiConfig";
-import { useTranslation } from 'react-i18next';  // 引入 useTranslation
+import { useTranslation } from 'react-i18next';
 
-export default function FloorSelector({ floor, setFloor, setClassroomCode }) {
+export default function FloorSelector({ floor, setFloor, setClassroomCode, showAllOption = false, disabled = false }) {
     const [floors, setFloors] = useState([]);
-    const { t } = useTranslation();  // 宣告 t 以便使用翻譯
+    const { t } = useTranslation();
 
     useEffect(() => {
         const fetchFloors = async () => {
@@ -18,7 +18,7 @@ export default function FloorSelector({ floor, setFloor, setClassroomCode }) {
             }
         };
         fetchFloors();
-    }, []);
+    }, [showAllOption]);
 
     const handleChange = (event) => {
         const value = event.target.value;
@@ -34,6 +34,7 @@ export default function FloorSelector({ floor, setFloor, setClassroomCode }) {
                 value={floor === null ? '全部' : floor}
                 onChange={handleChange}
                 label={t('樓層')}
+                disabled={disabled}
             >
                 {floors.map((floorValue) => (
                     <MenuItem key={floorValue} value={floorValue}>

--- a/frontend/src/key_status_UI/UpdateKeyStatus.js
+++ b/frontend/src/key_status_UI/UpdateKeyStatus.js
@@ -104,8 +104,7 @@ const UpdateKeyStatus = ({ open, onClose, classroomId, initialFloor, initialClas
                                 </Box>
                                 <Box sx={{ paddingTop: 1.5, paddingBottom: 1.5, paddingLeft: 4, paddingRight: 4 }}>
                                     <FloorAndClassroomCodeSelector
-                                        floor={floor} setFloor={setFloor}
-                                        classroomCode={classroomCode} setClassroomCode={setClassroomCode}
+                                        floor={floor} setFloor={setFloor} classroomCode={classroomCode} setClassroomCode={setClassroomCode} disabled={true}
                                     />
                                 </Box>
                                 <CardContent sx={{ paddingTop: 1.5, paddingBottom: 2, paddingLeft: 4, paddingRight: 4 }}>

--- a/frontend/src/query_information/information_strip.js
+++ b/frontend/src/query_information/information_strip.js
@@ -3,7 +3,16 @@ import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 export default function Informaion_strip({ user, classroomId, rentalDate, isRented, floor, endTime }) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+
+    const isChinese = i18n.language === 'zh_tw';
+    const styles = {
+        classroomIdWidth: isChinese ? "160px" : "180px",
+        floorWidth: isChinese ? "110px" : "110px",
+        userWidth: isChinese ? "180px" : "200px",
+        rentalTimeWidth: isChinese ? "450px" : "460px",
+        isRentedWidth: isChinese ? "160px" : "160px",
+    };
 
     return (
         <Box
@@ -19,19 +28,19 @@ export default function Informaion_strip({ user, classroomId, rentalDate, isRent
             }}
         >
             <Box sx={{ display: 'flex' }}>
-                <Typography variant="body1" sx={{ minWidth: "160px" }}>
+                <Typography variant="body1" sx={{ minWidth: styles.classroomIdWidth }}>
                     {t('教室編號')}: {classroomId}
                 </Typography>
-                <Typography variant="body1" sx={{ minWidth: "90px" }}>
+                <Typography variant="body1" sx={{ minWidth: styles.floorWidth }}>
                     {t('樓層')}: {floor}
                 </Typography>
-                <Typography variant="body1" sx={{ minWidth: "200px" }}>
+                <Typography variant="body1" sx={{ minWidth: styles.userWidth }}>
                     {t('借用人')}: {t(user)}&nbsp;&nbsp;
                 </Typography>
-                <Typography variant="body1" sx={{ minWidth: "470px" }}>
+                <Typography variant="body1" sx={{ minWidth: styles.rentalTimeWidth }}>
                     {t('借用時間')}: {rentalDate}&nbsp; {t('到')} &nbsp;{endTime}&nbsp;&nbsp;
                 </Typography>
-                <Typography variant="body1" sx={{ minWidth: "160px" }}>
+                <Typography variant="body1" sx={{ minWidth: styles.isRentedWidth }}>
                     {t('審查結果')}: {isRented}&nbsp;&nbsp;
                 </Typography>
             </Box>

--- a/frontend/src/query_information/query_information_interface.js
+++ b/frontend/src/query_information/query_information_interface.js
@@ -120,8 +120,8 @@ export default function Query_information_interface() {
                                 />
                             ))
                         ) : (
-                            <Typography sx={{ textAlign: "center", marginTop: "20px" }}>
-                                {t("沒有符合的使用者")}
+                            <Typography variant="body1" sx={{ textAlign: 'center', marginTop: 2, marginBottom: 2 }}>
+                                {t("沒有找到相關的使用者資訊，請檢查後端是否已經啟動，並且資料庫中確實存在資料")}
                             </Typography>
                         )}
                     </Box>

--- a/frontend/src/translation/i18n.js
+++ b/frontend/src/translation/i18n.js
@@ -147,7 +147,11 @@ const resources = {
             "2樓": "2nd Floor",
             "3樓": "3rd Floor",
             "4樓": "4th Floor",
-            "樓層選擇": "Floor Selection"
+            "樓層選擇": "Floor Selection",
+            "沒有找到相關的教室，請檢查後端是否已經啟動，並且資料庫中確實存在資料": "No relevant classroom found. Please check if the backend is running and the database contains the data.",
+            "沒有找到相關的使用者，請檢查後端是否已經啟動，並且資料庫中確實存在資料": "No relevant user found. Please check if the backend is running and the database contains the data.",
+            "沒有找到相關的申請，請檢查後端是否已經啟動，並且資料庫中確實存在資料": "No relevant application found. Please check if the backend is running and the database contains the data.",
+            "沒有找到相關的使用者資訊，請檢查後端是否已經啟動，並且資料庫中確實存在資料": "No relevant user information found. Please check if the backend is running and the database contains the data."
         }
     },
 

--- a/frontend/src/user_isbanned_status_UI/UserList.js
+++ b/frontend/src/user_isbanned_status_UI/UserList.js
@@ -33,7 +33,9 @@ export default function UserList({ user, reload, setReload }) {
     return (
         <Paper elevation={3} sx={{ padding: '20px', marginTop: '20px' }}>
             {usersToDisplay.length === 0 ? (
-                <Typography variant="body1">{t('沒有找到相關的使用者。')}</Typography>
+                <Typography variant="body1" sx={{ textAlign: 'center', marginTop: 2, marginBottom: 2 }}>
+                    {t("沒有找到相關的使用者，請檢查後端是否已經啟動，並且資料庫中確實存在資料")}
+                </Typography>
             ) : (
                 usersToDisplay.map((user) => (
                     <Box


### PR DESCRIPTION
1. 調整List所有資料的間距，中英文有分別
2. 後端多了一個方法用來delete borrower=null的資料，先留著，但應該不會出現borrower=null的情況
3. 讓樓層和教室編號選擇器，根據不同呼叫的父元件，選擇顯示或不顯示'全部'選項
4. 關閉更改鑰匙狀態和和禁用教室的選擇樓層和教室編號的權限，因為這兩個功能本來就沒有預期可以切換樓層來使用 理應解決YSJ-CA-08、YSJ-RK-08(舊版本的測試)